### PR TITLE
One-hot data generated in loadModel depending on type of model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ venv/
 _venv/
 __pycache__/
 _tmp/
+.idea/
 
 ### LaTeX ###
 ## Core latex/pdflatex auxiliary files:

--- a/loadModel.py
+++ b/loadModel.py
@@ -46,7 +46,11 @@ def loadModelForDataset(model_class, dataset_string, scm_class = None, experimen
   if not (dataset_string in {'synthetic', 'mortgage', 'twomoon', 'german', 'credit', 'compass', 'adult', 'test'}):
     raise Exception(f'{dataset_string} not supported.')
 
-  dataset_obj = loadData.loadDataset(dataset_string, return_one_hot = True, load_from_cache = False, meta_param = scm_class)
+  if model_class in {'tree', 'forest'}:
+    one_hot = False
+  elif model_class in {'lr', 'mlp'}:
+    one_hot = True
+  dataset_obj = loadData.loadDataset(dataset_string, return_one_hot = one_hot, load_from_cache = False, meta_param = scm_class)
   X_train, X_test, y_train, y_test = dataset_obj.getTrainTestSplit()
   X_all = pd.concat([X_train, X_test], axis = 0)
   y_all = pd.concat([y_train, y_test], axis = 0)


### PR DESCRIPTION
When attempting to run batch tests, I was running into trouble running batch tests for random forest and decision tree models because one hot data was always being generated in loadModelForDataset(), but one hot data was generated in batchTest.py only if the model was logistic regression or multilayer perceptron. I fixed this by adding a check for model type and converting to one-hot data only when necessary.